### PR TITLE
Pass base url option, use it to find css

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,20 @@ yarn start
    
 ### 2. Open new terminal windows
 ```sh
-npx docusaurus-pdf <initialDocsUrl> [filename]
+npx docusaurus-pdf <initialDocsUrl> [filename] [baseUrl]
 ```
 
 For example
 ```sh
-npx docusaurus-pdf http://localhost:3000/docs/doc1 hoge.pdf
+npx docusaurus-pdf http://localhost:3000/myurl/docs/doc1 hoge.pdf myurl
 ```
 
 *NOTE!
-- `initialDocsUrl` is required
-- `filename` is optional.(default is `docusaurus.pdf`)
+- `initialDocsUrl` is required.
+- `filename` is optional (default is `docusaurus.pdf`).
+- `baseUrl` is the baseUrl setting from docusaurus.config.js. 
+It is optional (default is empty string).
+You must specify a filename to use a custom baseUrl.
 
 ## Link of PDF
 1. Move generated pdf file to `static/img` folder.

--- a/bin/index.js
+++ b/bin/index.js
@@ -7,11 +7,11 @@ const { generatePdf } = require('../lib');
 program
   .version(require('../package.json').version)
   .name('docusaurus-pdf')
-  .usage('<initialDocsUrl> [filename]')
+  .usage('<initialDocsUrl> [filename] [baseUrl]')
   .description('Generate PDF from initial docs url')
-  .arguments('<initialDocsUrl> [filename]')
-  .action((initialDocsUrl, filename) => {
-    generatePdf(initialDocsUrl, filename)
+  .arguments('<initialDocsUrl> [filename] [baseUrl]')
+  .action((initialDocsUrl, filename, baseUrl) => {
+    generatePdf(initialDocsUrl, filename, baseUrl)
       .then((res) => {
         console.log(chalk.green('Finish generating PDF!'));
         process.exit(0);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-pdf",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Generate pdf from docusaurus document",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,12 +18,18 @@ const mergePdfBuffers = (pdfBuffers: Array<Buffer>) => {
   return outStream.toBuffer();
 };
 
+const safeUrlAppend = (origin: String, path: String, file: String) => {
+  return origin + (path.length > 0 ? '/' : '') + 
+    path.substring(path.startsWith('/') ? 1 : 0, path.length - (path.endsWith('/') ? 1 : 0)) + 
+    '/' + file;
+}
 
 let generatedPdfBuffers: Array<Buffer> = [];
 
 export async function generatePdf(
   initialDocsUrl: string,
-  filename = "docusaurus.pdf"
+  filename = "docusaurus.pdf",
+  baseUrl = ''
 ): Promise<void> {
   const browser = await puppeteer.launch();
   let page = await browser.newPage();
@@ -55,8 +61,8 @@ export async function generatePdf(
   
     
     await page.setContent(html);
-    await page.addStyleTag({url: `${origin}/styles.css`});
-    await page.addScriptTag({url: `${origin}/styles.js`});
+    await page.addStyleTag({url: safeUrlAppend(origin, baseUrl,'styles.css')});
+    await page.addScriptTag({url: safeUrlAppend(origin, baseUrl, 'styles.js')});
     const pdfBuffer = await page.pdf({path: "", format: 'A4', printBackground: true, margin : {top: 25, right: 35, left: 35, bottom: 25}});
 
     generatedPdfBuffers.push(pdfBuffer);


### PR DESCRIPTION
The current version fails to find the style files if the Docusaurus app uses a baseUrl. This passes in the baseUrl and correctly finds the css.