### PR TITLE
feat: support generating PDF for hosted docusaurus site

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,17 @@ yarn start
    
 ### 2. Open new terminal windows
 ```sh
-npx docusaurus-pdf <initialDocsUrl> [filename] [baseUrl]
+npx docusaurus-pdf <initialDocsUrl> [filename]
 ```
 
 For example
 ```sh
-npx docusaurus-pdf http://localhost:3000/myurl/docs/doc1 hoge.pdf myurl
+npx docusaurus-pdf http://localhost:3000/myBaseUrl/docs/doc1 hoge.pdf
 ```
 
 *NOTE!
 - `initialDocsUrl` is required.
 - `filename` is optional (default is `docusaurus.pdf`).
-- `baseUrl` is the baseUrl setting from docusaurus.config.js. 
-It is optional (default is empty string).
-You must specify a filename to use a custom baseUrl.
 
 ## Link of PDF
 1. Move generated pdf file to `static/img` folder.

--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ This is generated PDF of official docusaurus website:
 https://drive.google.com/file/d/19P3qSwLLUHYigrxH3QXIMXmRpTFi4pKB/view
 
 ## Usage
-### 1. Start your docusaurus project
-```sh
-yarn start
-```
-   
-### 2. Open new terminal windows
 ```sh
 npx docusaurus-pdf <initialDocsUrl> [filename]
 ```
@@ -26,7 +20,7 @@ npx docusaurus-pdf http://localhost:3000/myBaseUrl/docs/doc1 hoge.pdf
 ```
 
 *NOTE!
-- `initialDocsUrl` is required.
+- `initialDocsUrl` is required. You can spin up your dev-webserver of docusaurus with `yarn start` or use an already hosted page.
 - `filename` is optional (default is `docusaurus.pdf`).
 
 ## Link of PDF

--- a/bin/index.js
+++ b/bin/index.js
@@ -7,11 +7,11 @@ const { generatePdf } = require('../lib');
 program
   .version(require('../package.json').version)
   .name('docusaurus-pdf')
-  .usage('<initialDocsUrl> [filename] [baseUrl]')
+  .usage('<initialDocsUrl> [filename]')
   .description('Generate PDF from initial docs url')
-  .arguments('<initialDocsUrl> [filename] [baseUrl]')
-  .action((initialDocsUrl, filename, baseUrl) => {
-    generatePdf(initialDocsUrl, filename, baseUrl)
+  .arguments('<initialDocsUrl> [filename]')
+  .action((initialDocsUrl, filename) => {
+    generatePdf(initialDocsUrl, filename)
       .then((res) => {
         console.log(chalk.green('Finish generating PDF!'));
         process.exit(0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-pdf",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -85,6 +85,11 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -177,10 +182,36 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
+    "extract-zip": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+      "requires": {
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "requires": {
         "pend": "~1.2.0"
       }
@@ -402,9 +433,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "2.9.0",
@@ -424,11 +455,11 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "ms": {
@@ -575,32 +606,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "extract-zip": {
-          "version": "1.6.7",
-          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-          "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
-          "requires": {
-            "concat-stream": "1.6.2",
-            "debug": "2.6.9",
-            "mkdirp": "0.5.1",
-            "yauzl": "2.4.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            }
-          }
         }
       }
     },
@@ -616,9 +621,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -718,6 +723,12 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "dev": true
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -750,11 +761,12 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-pdf",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "Generate pdf from docusaurus document",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "author": "kohheepeace",
   "license": "MIT",
   "devDependencies": {
-    "@types/puppeteer": "^2.0.1"
+    "@types/puppeteer": "^2.0.1",
+    "typescript": "^3.8.3"
   },
   "dependencies": {
     "chalk": "^3.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ const { WritableStream } = require('memory-streams');
 const fs = require('fs');
 
 const mergePdfBuffers = (pdfBuffers: Array<Buffer>) => {
-  const outStream = new WritableStream();                                                                                                                                             
+  const outStream = new WritableStream();
   const [firstPdfRStream, ...restPdfRStreams] = pdfBuffers.map(pdfBuffer => new PDFRStreamForBuffer(pdfBuffer));
   const pdfWriter = createWriterToModify(firstPdfRStream, new PDFStreamForResponse(outStream));
 
@@ -14,14 +14,43 @@ const mergePdfBuffers = (pdfBuffers: Array<Buffer>) => {
 
   pdfWriter.end();
   outStream.end();
-  
+
   return outStream.toBuffer();
 };
 
-const safeUrlAppend = (origin: String, path: String, file: String) => {
-  return origin + (path.length > 0 ? '/' : '') + 
-    path.substring(path.startsWith('/') ? 1 : 0, path.length - (path.endsWith('/') ? 1 : 0)) + 
-    '/' + file;
+const getURL = (origin: string, filePath: string) => {
+  return origin + "/" + filePath.substring(filePath.startsWith('/') ? 1 : 0);
+}
+
+const getStylesheetPathFromHTML = (html: string, origin: string) => {
+  let regExp = /(?:|<link.*){1}href="(.*styles.*?\.css){1}"/g;
+  let filePath = "";
+  try {
+    filePath = getFirstCapturingGroup(regExp, html);
+  } catch {
+    throw new Error("The href attribute of the 'styles*.css' file could not be found!");
+  }
+  return getURL(origin, filePath);
+};
+
+const getScriptPathFromHTML = (html: string, origin: string) => {
+  let regExp = /(?:|<script.*){1}src="(.*styles.*?\.js){1}"/g;
+  let filePath = "";
+  try {
+    filePath = getFirstCapturingGroup(regExp, html);
+  } catch {
+    throw new Error("The src attribute of the 'styles*.js' file could not be found!");
+  }
+  return getURL(origin, filePath);
+};
+
+const getFirstCapturingGroup = (regExp: RegExp, text: string) => {
+  let match = regExp.exec(text);
+  if (match && match[1]) {
+    return match[1];
+  } else {
+    throw new ReferenceError("No capture group found in the provided text.")
+  }
 }
 
 let generatedPdfBuffers: Array<Buffer> = [];
@@ -37,6 +66,9 @@ export async function generatePdf(
   const url = new URL(initialDocsUrl);
   const origin = url.origin;
 
+  let stylePath: string = "";
+  let scriptPath: string = "";
+
   let nextPageUrl = initialDocsUrl;
 
   while (nextPageUrl) {
@@ -44,8 +76,13 @@ export async function generatePdf(
     console.log(chalk.cyan(`Generating PDF of ${nextPageUrl}`));
     console.log();
 
-    await page.goto(`${nextPageUrl}`, {waitUntil: 'networkidle2'});
-      
+    await page.goto(`${nextPageUrl}`, { waitUntil: 'networkidle2' })
+      .then((resp) => resp?.text())
+      .then((html) => {
+        stylePath = getStylesheetPathFromHTML(html!, origin);
+        scriptPath = getScriptPathFromHTML(html!, origin);
+      });
+
     try {
       nextPageUrl = await page.$eval('.pagination-nav__item--next > a', (element) => {
         return (element as HTMLLinkElement).href;
@@ -53,17 +90,17 @@ export async function generatePdf(
     } catch (e) {
       nextPageUrl = "";
     }
-  
-  
+
+
     let html = await page.$eval('article', (element) => {
       return element.outerHTML;
     });
-  
-    
+
+
     await page.setContent(html);
-    await page.addStyleTag({url: safeUrlAppend(origin, baseUrl,'styles.css')});
-    await page.addScriptTag({url: safeUrlAppend(origin, baseUrl, 'styles.js')});
-    const pdfBuffer = await page.pdf({path: "", format: 'A4', printBackground: true, margin : {top: 25, right: 35, left: 35, bottom: 25}});
+    await page.addStyleTag({ url: stylePath });
+    await page.addScriptTag({ url: scriptPath });
+    const pdfBuffer = await page.pdf({ path: "", format: 'A4', printBackground: true, margin: { top: 25, right: 35, left: 35, bottom: 25 } });
 
     generatedPdfBuffers.push(pdfBuffer);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,8 +78,9 @@ export async function generatePdf(
     await page.goto(`${nextPageUrl}`, { waitUntil: 'networkidle2' })
       .then((resp) => resp?.text())
       .then((html) => {
-        stylePath = getStylesheetPathFromHTML(html!, origin);
-        scriptPath = getScriptPathFromHTML(html!, origin);
+        if (!html) throw new Error(`Page could not be loaded! Did not get any HTML for ${nextPageUrl}`)
+        stylePath = getStylesheetPathFromHTML(html, origin);
+        scriptPath = getScriptPathFromHTML(html, origin);
       });
 
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,8 +57,7 @@ let generatedPdfBuffers: Array<Buffer> = [];
 
 export async function generatePdf(
   initialDocsUrl: string,
-  filename = "docusaurus.pdf",
-  baseUrl = ''
+  filename = "docusaurus.pdf"
 ): Promise<void> {
   const browser = await puppeteer.launch();
   let page = await browser.newPage();


### PR DESCRIPTION
Hey @KohheePeace!

I added support for docusaurus websites which where built and are hosted somewhere. So people don't need the sources and don't have to run `npx docusaurus start`. 

Now there is some code which extracts the `styles*.js` and `styles*.css` from the HTML in order to be able to support websites which were created by `docusaurus build`.
The function [`text()`](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#responsetext) is used on the response of [`page.goto()`](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagegotourl-options) to get the HTML of the page.
Next, some regex is used to extract the paths of the mentioned files.

As a consequence I removed the newly introduced `baseUrl` parameter because I didn't see any further necessity to keep it. Because this is a non backward compatible change I bumped the version to `1.0.0`. But feel free to adjust this if you like to handle the versioning in another way.

What do you think about this little change?