### PR TITLE
feat: dockerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init
 
-WORKDIR /app
+WORKDIR /usr/src/app
 
 COPY package*.json ./
 RUN npm install
@@ -21,6 +21,6 @@ RUN npm install
 COPY . .
 RUN npm run build
 
-ENTRYPOINT ["dumb-init", "--", "node", "./bin/index.js"]
+ENTRYPOINT ["dumb-init", "--", "node", "/usr/src/app/bin/index.js"]
 
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:12-slim
+
+# https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
+RUN apt-get update \
+    && apt-get install -y wget gnupg \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+ENTRYPOINT ["dumb-init", "--", "node", "./bin/index.js"]
+
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ npx docusaurus-pdf from-build build/ docs/doc1 /myBaseUrl/
 - Optional: If you have a `baseUrl` configured in your `docusaurus.config.js` then pass this value as `baseUrl`.
 - Note: There is a optional parameter to set a custom filename. You can see further details using `npx docusaurus-pdf from-build --help`.
 
+## Docker usage
+All dependencies needed to create a PDF from your docusaurus site are bundled in our Dockerfile.
+
+### Create PDF from build artifact
+#### Run docusaurus-pdf with prebuild image
+```sh
+docker run --rm -it -v /someDir/my-docusaurus:/workspace maxys/docusaurus-pdf:latest from-build --no-sandbox -o /workspace/build/docs.pdf /workspace/build docs/doc1 myBaseUrl
+```
+
+#### Build Docker image locally
+You can create the image locally without pulling `maxys/docusaurus-pdf:latest` from the Docker Hub with:
+
+```sh
+docker build -t "docusaurus-pdf" .
+```
+
 ## Link of PDF
 1. Move generated pdf file to `static/img` folder.
 2. `<a>` tag with `target="_blank"`

--- a/bin/index.js
+++ b/bin/index.js
@@ -26,8 +26,10 @@ program
   .command('from-build <dirPath> <firstDocPagePath> [baseUrl]')
   .description('Generate PDF from a docusaurus build artifact')
   .option('-o, --output-file [name]', 'Specify your file name. Default is docusaurus.pdf')
+  .option('--no-sandbox', 'Start puppeteer with --no-sandbox flag')
   .action((dirPath, firstDocPagePath, baseUrl, options) => {
-    generatePdfFromBuildSources(dirPath, firstDocPagePath, baseUrl, options.outputFile)
+    const puppeteerArgs = options.sandbox ? [] : ['--no-sandbox'];
+    generatePdfFromBuildSources(dirPath, firstDocPagePath, baseUrl, options.outputFile, puppeteerArgs)
       .then((res) => {
         console.log(chalk.green('Finish generating PDF!'));
         process.exit(0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,9 +75,10 @@ const getPathSegment = (path: string, slashIfEmpty: boolean = true) => {
 
 export async function generatePdf(
   initialDocsUrl: string,
-  filename = "docusaurus.pdf"
+  filename = "docusaurus.pdf",
+  puppeteerArgs: Array<string>
 ): Promise<void> {
-  const browser = await puppeteer.launch({ args: ['--no-sandbox'] });
+  const browser = await puppeteer.launch({ args: puppeteerArgs });
   let page = await browser.newPage();
 
   const url = new URL(initialDocsUrl);
@@ -134,7 +135,8 @@ export async function generatePdfFromBuildSources(
   buildDirPath: string,
   firstDocPath: string,
   baseUrl: string,
-  filename: string = "docusaurus.pdf"
+  filename: string = "docusaurus.pdf",
+  puppeteerArgs: Array<string>
 ): Promise<void> {
   let app = express();
 
@@ -150,6 +152,6 @@ export async function generatePdfFromBuildSources(
 
   app.use(baseUrl, express.static(buildDirPath));
 
-  await generatePdf(`http://127.0.0.1:${address.port}${baseUrl}${firstDocPath}`, filename)
+  await generatePdf(`http://127.0.0.1:${address.port}${baseUrl}${firstDocPath}`, filename, puppeteerArgs)
     .then(() => httpServer.close());
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export async function generatePdf(
   initialDocsUrl: string,
   filename = "docusaurus.pdf"
 ): Promise<void> {
-  const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch({ args: ['--no-sandbox'] });
   let page = await browser.newPage();
 
   const url = new URL(initialDocsUrl);


### PR DESCRIPTION
Hey @KohheePeace!

I struggled for a long time using this program in a CD pipeline because of the special dependencies needed by puppeteer.

There are some docker images on the Docker Hub which provide all these dependencies but unfortunately they all have some limitations. Some of them enforce you to call `puppeteer.launch()` with  `{ args: ['--no-sandbox'] }` as argument which is currently not set in the app. Others need to have the `--cap-add=SYS_ADMIN` flag set on `docker run`. The latter is not possible for GitHub Actions for example (see [docs](https://help.github.com/en/actions/building-actions/dockerfile-support-for-github-actions#supported-linux-capabilities)). 

Because of this I decided to dockerize this application to have it working without any other dependencies.
I used the [Dockerfile template](https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker) provided in the puppeteer repo and it works quiet well. Because of the `--no-sandbox` limitation of puppeteer I introduced another option (at least for the `from-build` action).

I updated the README.md and uploaded the docker image to my Docker Hub. Please give it a try:
```
docker run --rm -it -v /someDir/my-docusaurus:/workspace maxys/docusaurus-pdf:latest from-build --no-sandbox -o /workspace/build/docs.pdf /workspace/build docs/doc1 myBaseUrl
```
Probably it would be best to link this repo as a Docker Hub image. If we do it this way we have the README.md shown up on the Docker Hub as well.

Now, using this tool in a CD pipeline should work. I will give it a try with GitHub Actions tomorrow. If this runs stable I can create a GitHub Action as well.

What do you think about it?
